### PR TITLE
Fix test failures caused by Docker API version mismatch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 	runtimeOnly("ch.qos.logback:logback-classic:1.5.21")
 	runtimeOnly("mysql:mysql-connector-java")
 
+	testImplementation(platform("org.testcontainers:testcontainers-bom:1.20.4"))
 	testImplementation("org.testcontainers:junit-jupiter")
 	testImplementation("org.testcontainers:mysql")
 	testImplementation("org.testcontainers:testcontainers")
@@ -73,6 +74,10 @@ dependencies {
 
 application {
 	mainClass.set("org.ethelred.kv2.Application")
+}
+
+tasks.named('test') {
+	systemProperty "api.version", "1.44"
 }
 
 tasks.named('run') {

--- a/rosterParser/src/main/java/org/ethelred/roster/Level.java
+++ b/rosterParser/src/main/java/org/ethelred/roster/Level.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.roster;
 
 public interface Level {

--- a/rosterParser/src/main/java/org/ethelred/roster/LevelImpl.java
+++ b/rosterParser/src/main/java/org/ethelred/roster/LevelImpl.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.roster;
 
 import java.util.ArrayList;

--- a/rosterParser/src/main/java/org/ethelred/roster/ParsedRoster.java
+++ b/rosterParser/src/main/java/org/ethelred/roster/ParsedRoster.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.roster;
 
 public interface ParsedRoster {

--- a/rosterParser/src/main/java/org/ethelred/roster/ParsedRosterImpl.java
+++ b/rosterParser/src/main/java/org/ethelred/roster/ParsedRosterImpl.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.roster;
 
 import java.util.ArrayList;

--- a/rosterParser/src/main/java/org/ethelred/roster/RosterParser.java
+++ b/rosterParser/src/main/java/org/ethelred/roster/RosterParser.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.roster;
 
 public interface RosterParser {

--- a/rosterParser/src/main/java/org/ethelred/roster/RosterParserImpl.java
+++ b/rosterParser/src/main/java/org/ethelred/roster/RosterParserImpl.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.roster;
 
 import java.util.LinkedList;

--- a/rosterParser/src/test/java/org/ethelred/roster/RosterParserTest.java
+++ b/rosterParser/src/test/java/org/ethelred/roster/RosterParserTest.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.roster;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/main/java/org/ethelred/kv2/Application.java
+++ b/src/main/java/org/ethelred/kv2/Application.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2;
 
 import io.micronaut.runtime.Micronaut;

--- a/src/main/java/org/ethelred/kv2/controllers/ApiRosterController.java
+++ b/src/main/java/org/ethelred/kv2/controllers/ApiRosterController.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.controllers;
 
 import io.micronaut.core.annotation.Nullable;

--- a/src/main/java/org/ethelred/kv2/controllers/MyExceptionHandlers.java
+++ b/src/main/java/org/ethelred/kv2/controllers/MyExceptionHandlers.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.controllers;
 
 import io.micronaut.context.annotation.Factory;

--- a/src/main/java/org/ethelred/kv2/controllers/UIRosterController.java
+++ b/src/main/java/org/ethelred/kv2/controllers/UIRosterController.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.controllers;
 
 import static org.ethelred.kv2.util.ViewsHelper.writable;

--- a/src/main/java/org/ethelred/kv2/data/IdentityRepository.java
+++ b/src/main/java/org/ethelred/kv2/data/IdentityRepository.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.data;
 
 import io.micronaut.data.jdbc.annotation.JdbcRepository;

--- a/src/main/java/org/ethelred/kv2/data/SimpleRosterRepository.java
+++ b/src/main/java/org/ethelred/kv2/data/SimpleRosterRepository.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.data;
 
 import io.micronaut.core.annotation.NonNull;

--- a/src/main/java/org/ethelred/kv2/data/UserRepository.java
+++ b/src/main/java/org/ethelred/kv2/data/UserRepository.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.data;
 
 import io.micronaut.data.annotation.Query;

--- a/src/main/java/org/ethelred/kv2/dev/DevAuthentication.java
+++ b/src/main/java/org/ethelred/kv2/dev/DevAuthentication.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.dev;
 
 import io.micronaut.context.annotation.Requires;

--- a/src/main/java/org/ethelred/kv2/dev/DevLoginController.java
+++ b/src/main/java/org/ethelred/kv2/dev/DevLoginController.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.dev;
 
 import io.micronaut.context.annotation.Requires;

--- a/src/main/java/org/ethelred/kv2/models/AssetsConfiguration.java
+++ b/src/main/java/org/ethelred/kv2/models/AssetsConfiguration.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.models;
 
 import io.micronaut.context.annotation.ConfigurationProperties;

--- a/src/main/java/org/ethelred/kv2/models/DefaultLayoutContext.java
+++ b/src/main/java/org/ethelred/kv2/models/DefaultLayoutContext.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.models;
 
 import io.micronaut.core.annotation.NonNull;

--- a/src/main/java/org/ethelred/kv2/models/DocumentStub.java
+++ b/src/main/java/org/ethelred/kv2/models/DocumentStub.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.models;
 
 import io.micronaut.data.annotation.MappedEntity;

--- a/src/main/java/org/ethelred/kv2/models/Identity.java
+++ b/src/main/java/org/ethelred/kv2/models/Identity.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.models;
 
 import io.micronaut.core.annotation.NonNull;

--- a/src/main/java/org/ethelred/kv2/models/Owned.java
+++ b/src/main/java/org/ethelred/kv2/models/Owned.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.models;
 
 import io.micronaut.core.annotation.NonNull;

--- a/src/main/java/org/ethelred/kv2/models/Owner.java
+++ b/src/main/java/org/ethelred/kv2/models/Owner.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.models;
 
 import java.io.Serializable;

--- a/src/main/java/org/ethelred/kv2/models/SimpleRoster.java
+++ b/src/main/java/org/ethelred/kv2/models/SimpleRoster.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.models;
 
 import io.micronaut.core.annotation.NonNull;

--- a/src/main/java/org/ethelred/kv2/models/User.java
+++ b/src/main/java/org/ethelred/kv2/models/User.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.models;
 
 import io.micronaut.core.annotation.Nullable;

--- a/src/main/java/org/ethelred/kv2/models/UserFlag.java
+++ b/src/main/java/org/ethelred/kv2/models/UserFlag.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.models;
 
 public enum UserFlag {

--- a/src/main/java/org/ethelred/kv2/models/UserFlagSetConverter.java
+++ b/src/main/java/org/ethelred/kv2/models/UserFlagSetConverter.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.models;
 
 import io.micronaut.core.convert.ConversionContext;

--- a/src/main/java/org/ethelred/kv2/models/Visibility.java
+++ b/src/main/java/org/ethelred/kv2/models/Visibility.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.models;
 
 import io.micronaut.core.annotation.Introspected;

--- a/src/main/java/org/ethelred/kv2/providers/OpenIdUserAuthenticationMapper.java
+++ b/src/main/java/org/ethelred/kv2/providers/OpenIdUserAuthenticationMapper.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.providers;
 
 import io.micronaut.context.annotation.Replaces;

--- a/src/main/java/org/ethelred/kv2/providers/discord/DiscordApiClient.java
+++ b/src/main/java/org/ethelred/kv2/providers/discord/DiscordApiClient.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.providers.discord;
 
 import io.micronaut.core.async.annotation.SingleResult;

--- a/src/main/java/org/ethelred/kv2/providers/discord/DiscordAuthenticationMapper.java
+++ b/src/main/java/org/ethelred/kv2/providers/discord/DiscordAuthenticationMapper.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.providers.discord;
 
 import io.micronaut.core.annotation.Nullable;

--- a/src/main/java/org/ethelred/kv2/providers/discord/DiscordGuild.java
+++ b/src/main/java/org/ethelred/kv2/providers/discord/DiscordGuild.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.providers.discord;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;

--- a/src/main/java/org/ethelred/kv2/providers/discord/DiscordUIAuthProvider.java
+++ b/src/main/java/org/ethelred/kv2/providers/discord/DiscordUIAuthProvider.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.providers.discord;
 
 import io.micronaut.core.annotation.Order;

--- a/src/main/java/org/ethelred/kv2/providers/discord/DiscordUser.java
+++ b/src/main/java/org/ethelred/kv2/providers/discord/DiscordUser.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.providers.discord;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;

--- a/src/main/java/org/ethelred/kv2/services/DefaultUserService.java
+++ b/src/main/java/org/ethelred/kv2/services/DefaultUserService.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.services;
 
 import io.micronaut.core.annotation.NonNull;

--- a/src/main/java/org/ethelred/kv2/services/GeneratedId.java
+++ b/src/main/java/org/ethelred/kv2/services/GeneratedId.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.services;
 
 import io.micronaut.data.annotation.*;

--- a/src/main/java/org/ethelred/kv2/services/GeneratedIdEntityEventListener.java
+++ b/src/main/java/org/ethelred/kv2/services/GeneratedIdEntityEventListener.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.services;
 
 import io.micronaut.core.beans.*;

--- a/src/main/java/org/ethelred/kv2/services/IdGenerator.java
+++ b/src/main/java/org/ethelred/kv2/services/IdGenerator.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.services;
 
 @FunctionalInterface

--- a/src/main/java/org/ethelred/kv2/services/KsuidFactory.java
+++ b/src/main/java/org/ethelred/kv2/services/KsuidFactory.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.services;
 
 import com.github.ksuid.KsuidGenerator;

--- a/src/main/java/org/ethelred/kv2/services/OwnerRequestArgumentBinder.java
+++ b/src/main/java/org/ethelred/kv2/services/OwnerRequestArgumentBinder.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.services;
 
 import io.micronaut.core.convert.ArgumentConversionContext;

--- a/src/main/java/org/ethelred/kv2/services/RosterParserFactory.java
+++ b/src/main/java/org/ethelred/kv2/services/RosterParserFactory.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.services;
 
 import io.micronaut.context.annotation.Factory;

--- a/src/main/java/org/ethelred/kv2/services/TemplatesFactory.java
+++ b/src/main/java/org/ethelred/kv2/services/TemplatesFactory.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.services;
 
 import gg.jte.ContentType;

--- a/src/main/java/org/ethelred/kv2/services/UserService.java
+++ b/src/main/java/org/ethelred/kv2/services/UserService.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.services;
 
 import io.micronaut.core.annotation.Nullable;

--- a/src/main/java/org/ethelred/kv2/util/AuthAttributesHelper.java
+++ b/src/main/java/org/ethelred/kv2/util/AuthAttributesHelper.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.util;
 
 import java.util.*;

--- a/src/main/java/org/ethelred/kv2/util/AuthenticationDebug.java
+++ b/src/main/java/org/ethelred/kv2/util/AuthenticationDebug.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.util;
 
 import io.micronaut.security.authentication.ServerAuthentication;

--- a/src/main/java/org/ethelred/kv2/util/Debug.java
+++ b/src/main/java/org/ethelred/kv2/util/Debug.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.util;
 
 import io.micronaut.aop.Around;

--- a/src/main/java/org/ethelred/kv2/util/DebugInterceptor.java
+++ b/src/main/java/org/ethelred/kv2/util/DebugInterceptor.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.util;
 
 import static org.ethelred.kv2.util.Lazy.lazy;

--- a/src/main/java/org/ethelred/kv2/util/DebugMapper.java
+++ b/src/main/java/org/ethelred/kv2/util/DebugMapper.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.util;
 
 public interface DebugMapper<T> {

--- a/src/main/java/org/ethelred/kv2/util/Lazy.java
+++ b/src/main/java/org/ethelred/kv2/util/Lazy.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.util;
 
 import java.util.function.Supplier;

--- a/src/main/java/org/ethelred/kv2/util/PatchHelper.java
+++ b/src/main/java/org/ethelred/kv2/util/PatchHelper.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.util;
 
 import io.micronaut.core.annotation.NonNull;

--- a/src/main/java/org/ethelred/kv2/util/ResourceContent.java
+++ b/src/main/java/org/ethelred/kv2/util/ResourceContent.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2024-2025 */
+/* (C) Edward Harman and contributors 2024-2026 */
 package org.ethelred.kv2.util;
 
 import gg.jte.Content;

--- a/src/main/java/org/ethelred/kv2/util/ResourceContentResolver.java
+++ b/src/main/java/org/ethelred/kv2/util/ResourceContentResolver.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2024-2025 */
+/* (C) Edward Harman and contributors 2024-2026 */
 package org.ethelred.kv2.util;
 
 import io.micronaut.core.io.ResourceResolver;

--- a/src/main/java/org/ethelred/kv2/util/ViewsHelper.java
+++ b/src/main/java/org/ethelred/kv2/util/ViewsHelper.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.util;
 
 import gg.jte.models.runtime.JteModel;

--- a/src/test/java/org/ethelred/kv2/Kv2Test.java
+++ b/src/test/java/org/ethelred/kv2/Kv2Test.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2;
 
 import io.micronaut.runtime.EmbeddedApplication;

--- a/src/test/java/org/ethelred/kv2/controllers/ApiRosterControllerTest.java
+++ b/src/test/java/org/ethelred/kv2/controllers/ApiRosterControllerTest.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/ethelred/kv2/data/UserRepositoryTest.java
+++ b/src/test/java/org/ethelred/kv2/data/UserRepositoryTest.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.data;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/ethelred/kv2/providers/TestAuthenticationProvider.java
+++ b/src/test/java/org/ethelred/kv2/providers/TestAuthenticationProvider.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.providers;
 
 import io.micronaut.http.HttpRequest;

--- a/src/test/java/org/ethelred/kv2/providers/TestDataLoader.java
+++ b/src/test/java/org/ethelred/kv2/providers/TestDataLoader.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.providers;
 
 import io.micronaut.core.io.scan.ClassPathResourceLoader;

--- a/src/test/java/org/ethelred/kv2/services/UserServiceTest.java
+++ b/src/test/java/org/ethelred/kv2/services/UserServiceTest.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2022-2025 */
+/* (C) Edward Harman and contributors 2022-2026 */
 package org.ethelred.kv2.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/teaClient/src/teavm/java/org/ethelred/kv2/client/Api.java
+++ b/teaClient/src/teavm/java/org/ethelred/kv2/client/Api.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.client;
 
 import org.slf4j.Logger;

--- a/teaClient/src/teavm/java/org/ethelred/kv2/client/CodeMirror.java
+++ b/teaClient/src/teavm/java/org/ethelred/kv2/client/CodeMirror.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.client;
 
 import org.teavm.jso.JSBody;

--- a/teaClient/src/teavm/java/org/ethelred/kv2/client/CodeMirrorEventListener.java
+++ b/teaClient/src/teavm/java/org/ethelred/kv2/client/CodeMirrorEventListener.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.client;
 
 import org.teavm.jso.JSFunctor;

--- a/teaClient/src/teavm/java/org/ethelred/kv2/client/Main.java
+++ b/teaClient/src/teavm/java/org/ethelred/kv2/client/Main.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.client;
 
 import org.ethelred.kv2.template.StaticTemplates;

--- a/teaClient/src/teavm/java/org/ethelred/kv2/client/SimpleMap.java
+++ b/teaClient/src/teavm/java/org/ethelred/kv2/client/SimpleMap.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.client;
 
 import org.teavm.jso.JSIndexer;

--- a/views/src/main/java/org/ethelred/kv2/viewmodels/Assets.java
+++ b/views/src/main/java/org/ethelred/kv2/viewmodels/Assets.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.viewmodels;
 
 import java.util.List;

--- a/views/src/main/java/org/ethelred/kv2/viewmodels/LayoutContext.java
+++ b/views/src/main/java/org/ethelred/kv2/viewmodels/LayoutContext.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.viewmodels;
 
 import io.micronaut.core.annotation.Nullable;

--- a/views/src/main/java/org/ethelred/kv2/viewmodels/StubView.java
+++ b/views/src/main/java/org/ethelred/kv2/viewmodels/StubView.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.viewmodels;
 
 public interface StubView {

--- a/views/src/main/java/org/ethelred/kv2/viewmodels/UIAuthProvider.java
+++ b/views/src/main/java/org/ethelred/kv2/viewmodels/UIAuthProvider.java
@@ -1,4 +1,4 @@
-/* (C) Edward Harman and contributors 2023-2025 */
+/* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.viewmodels;
 
 public interface UIAuthProvider {


### PR DESCRIPTION
## Summary
- Upgrade TestContainers BOM from 1.17.6 (Micronaut-pinned) to 1.20.4 to get a newer docker-java transport
- Add `systemProperty "api.version", "1.44"` to the test task so the docker-java client negotiates API 1.44 instead of defaulting to 1.32
- Docker Engine 29.x enforces a minimum API version of 1.40, which caused all 4 integration tests to fail with `BadRequestException: client version 1.32 is too old`

## Test Plan
- [ ] Run `./gradlew :test` — all tests should pass
- [ ] Confirm `Found Docker environment with local Unix socket` appears in test output (not a Docker environment error)