### PR TITLE
Remove unused native-image component from GraalVM CI setup

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,7 +21,6 @@ jobs:
       with:
         version: 'latest'
         java-version: '17'
-        components: 'native-image'
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
## Summary

- Removes `components: 'native-image'` from the `graalvm/setup-graalvm` action in the CI workflow
- The project does not use GraalVM native image compilation — no native plugin, no `nativeCompile` task, no native configuration exists anywhere in the build
- This line was causing `gu` (GraalVM Updater) to contact `gds.oracle.com` which is timing out, failing CI on all PRs

## Effect

Unblocks three stalled Renovate PRs: #388 (tailwindcss v4), #389 (Gradle v9), #400 (setup-node v6).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)