### PR TITLE
Phase 2: wire JTE directly via jte-models, remove micronaut-views-jte

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ dependencies {
 	implementation("io.micronaut.security:micronaut-security-jwt")
 	implementation("io.micronaut.security:micronaut-security-oauth2")
 	implementation("io.micronaut.sql:micronaut-jdbc-hikari")
-	implementation("io.micronaut.views:micronaut-views-jte")
 	runtimeOnly("gg.jte:jte:3.2.3")
 	implementation("io.micronaut.reactor:micronaut-reactor")
 	implementation("io.micronaut.reactor:micronaut-reactor-http-client")

--- a/src/main/java/org/ethelred/kv2/services/TemplatesFactory.java
+++ b/src/main/java/org/ethelred/kv2/services/TemplatesFactory.java
@@ -5,8 +5,7 @@ import gg.jte.ContentType;
 import gg.jte.TemplateEngine;
 import gg.jte.resolve.DirectoryCodeResolver;
 import io.micronaut.context.annotation.Factory;
-import io.micronaut.context.annotation.Property;
-import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
 import jakarta.inject.Singleton;
 import java.nio.file.Paths;
 import org.ethelred.kv2.template.DynamicTemplates;
@@ -16,21 +15,13 @@ import org.ethelred.kv2.template.Templates;
 @Factory
 public class TemplatesFactory {
     @Singleton
-    @Requires(property = "micronaut.views.jte.dynamic", value = "false", defaultValue = "false")
-    public Templates staticTemplates() {
+    public Templates templates(
+            @Value("${kv2.jte.dynamic:false}") boolean dynamic,
+            @Value("${kv2.jte.dynamic-source-path:views/src/main/jte}") String templatePath) {
+        if (dynamic) {
+            var engine = TemplateEngine.create(new DirectoryCodeResolver(Paths.get(templatePath)), ContentType.Html);
+            return new DynamicTemplates(engine);
+        }
         return new StaticTemplates();
-    }
-
-    @Singleton
-    @Requires(property = "micronaut.views.jte.dynamic", value = "true")
-    public Templates dynamicTemplates(TemplateEngine engine) {
-        return new DynamicTemplates(engine);
-    }
-
-    @Singleton
-    @Requires(property = "micronaut.views.jte.dynamic", value = "true")
-    public TemplateEngine newDynamicTemplateEngine(
-            @Property(name = "micronaut.views.jte.dynamic-source-path") String templatePath) {
-        return TemplateEngine.create(new DirectoryCodeResolver(Paths.get(templatePath)), ContentType.Html);
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,11 +1,11 @@
+kv2:
+  jte:
+    dynamic: true
+    dynamic-source-path: views/src/main/jte
 micronaut:
   http:
     client:
       log-level: DEBUG
-  views:
-    jte:
-      dynamic: true
-      dynamic-source-path: views/src/main/jte
   router:
     static-resources:
       assets:

--- a/views/build.gradle
+++ b/views/build.gradle
@@ -1,9 +1,8 @@
 plugins {
-	id 'java'
+	id 'java-library'
 	id("gg.jte.gradle") version "3.2.3"
 	id("org.ethelred.kv2.java-conventions")
 	id "com.github.node-gradle.node" version "7.1.0"
-	id("io.micronaut.minimal.library")
 }
 
 version = "0.1"
@@ -15,13 +14,11 @@ repositories {
 }
 
 dependencies {
-	annotationProcessor("io.micronaut:micronaut-inject")
 	implementation("gg.jte:jte:3.2.3")
 	jteGenerate("gg.jte:jte-models:3.2.3")
 	api("gg.jte:jte-models:3.2.3")
 	implementation(project(":rosterParser"))
-	implementation("io.micronaut:micronaut-core") // used for nullability annotations
-	implementation("jakarta.inject:jakarta.inject-api:2.0.1") // used for generated template providers
+	compileOnly('org.jspecify:jspecify:1.0.0')
 }
 
 jte {
@@ -52,6 +49,3 @@ tasks.named("jar") {
 	dependsOn("generateCss")
 }
 
-tasks.named("inspectRuntimeClasspath") {
-	dependsOn(tasks.named("generateJte"))
-}

--- a/views/src/main/java/org/ethelred/kv2/viewmodels/LayoutContext.java
+++ b/views/src/main/java/org/ethelred/kv2/viewmodels/LayoutContext.java
@@ -1,7 +1,7 @@
 /* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.viewmodels;
 
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Objects;
 import java.util.regex.Pattern;
 

--- a/views/src/main/java/org/ethelred/kv2/viewmodels/LayoutContext.java
+++ b/views/src/main/java/org/ethelred/kv2/viewmodels/LayoutContext.java
@@ -1,9 +1,9 @@
 /* (C) Edward Harman and contributors 2023-2026 */
 package org.ethelred.kv2.viewmodels;
 
-import org.jspecify.annotations.Nullable;
 import java.util.Objects;
 import java.util.regex.Pattern;
+import org.jspecify.annotations.Nullable;
 
 public interface LayoutContext {
     String title();


### PR DESCRIPTION
## Summary
- Remove `micronaut-views-jte` from main `build.gradle` — controllers already use `jte-models` (`Templates` interface) directly, so this was unused
- Remove Micronaut library plugin, `micronaut-inject` annotation processor, and `micronaut-core` from `views` subproject; switch to `java-library`; add `jspecify` for `@Nullable`
- Fix `LayoutContext.java` to use `org.jspecify.annotations.Nullable` instead of the Micronaut one
- Simplify `TemplatesFactory` from three `@Requires(property=...)` conditional beans to a single method with `@Value` injection; rename property key from `micronaut.views.jte.*` to `kv2.jte.*`

## Test plan
- [ ] CI passes
- [ ] Dev mode hot-reload still works (`kv2.jte.dynamic=true` in `application-dev.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)