### PR TITLE
Phase 6: remove remaining Micronaut configuration artefacts

### DIFF
--- a/micronaut-cli.yml
+++ b/micronaut-cli.yml
@@ -1,6 +1,0 @@
-applicationType: default
-defaultPackage: org.ethelred.kv2
-testFramework: junit
-sourceLanguage: java
-buildTool: gradle
-features: [annotation-api, app-name, data, data-jdbc, gradle, http-client, java, java-application, jdbc-hikari, junit, liquibase, logback, micronaut-build, mysql, netty-server, reactor, reactor-http-client, readme, security, security-annotations, security-jwt, security-oauth2, shade, testcontainers, views-rocker, yaml]

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -19,15 +19,7 @@
         </encoder>
     </appender>
 
-    <!-- <logger name="io.micronaut.http.client.netty.DefaultHttpClient" level="trace"/> -->
-<!--    <logger name="io.micronaut.context" level="TRACE"/>-->
-<!--    <logger name="io.micronaut.aop" level="DEBUG"/>-->
-<!--    <logger name="io.micronaut.security" level="DEBUG"/>-->
-<!--    <logger name="io.micronaut.servlet.http" level="DEBUG"/>-->
     <logger name="org.ethelred" level="DEBUG"/>
-<!--    <logger name="org.ethelred.cgi.standalone" level="INFO"/>-->
-<!--    <logger name="io.micronaut.web.router" level="DEBUG"/>-->
-    <logger name="io.micronaut.http.server" level="DEBUG"/>
     <logger name="HTTP_ACCESS_LOGGER" level="debug"/>
     <root level="info">
         <appender-ref ref="STDOUT" />

--- a/views/build.gradle
+++ b/views/build.gradle
@@ -24,9 +24,6 @@ dependencies {
 jte {
 	generate()
 	jteExtension("gg.jte.models.generator.ModelExtension") {
-		//		property("implementationAnnotation", "@jakarta.inject.Singleton")
-		//		property("staticAnnotation", "@io.micronaut.context.annotation.Secondary")
-		//		property("dynamicAnnotation", """@io.micronaut.context.annotation.Requires(property = "micronaut.views.jte.dynamic", value = "true")""")
 	}
 	// TODO binaryStaticContent = true
 	packageName = 'org.ethelred.kv2.template'


### PR DESCRIPTION
## Summary

Phase 6 was largely completed as part of Phase 4 (config already uses avaje-config, no `@ConfigurationProperties`, no Micronaut stanzas in `application.yml`). This PR removes the last stragglers:

- **`logback.xml`**: deleted 6 commented-out Micronaut logger entries and one active `io.micronaut.http.server` logger that does nothing since the migration
- **`views/build.gradle`**: removed 3 commented-out Micronaut jte extension annotation properties left over from the old Micronaut views setup
- **`micronaut-cli.yml`**: deleted — this is Micronaut CLI project metadata, no longer relevant

## Test plan

- [x] All 15 tests pass (`./gradlew :test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)