### PR TITLE
Phase 7+8: remove last Micronaut artefact, completing migration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,3 @@
-micronautVersion=3.9.3
-
 # spotless / google java format workaround https://github.com/diffplug/spotless/tree/main/plugin-gradle
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \


### PR DESCRIPTION
## Summary

Closes out the Micronaut → Avaje migration.

- **Phase 7** (Liquibase direct) was already completed as part of Phase 4 — `DataSourceFactory` runs Liquibase at startup without any Micronaut involvement.
- **Phase 8** (final cleanup): removes the one remaining Micronaut trace — the unused `micronautVersion=3.9.3` property in `gradle.properties`.

After this PR, `grep -r "micronaut"` across all source, config, and build files returns nothing.

## Test plan

- [x] All 15 tests pass (`./gradlew :test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)