### PR TITLE
Gradle 9 upgrade: remove Shadow plugin, bump Spotless to 8.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 plugins {
 	id 'java'
 	id 'application'
-	id("com.github.johnrengelman.shadow") version "8.1.1"
 	id("org.ethelred.kv2.java-conventions")
 	id "co.uzzu.dotenv.gradle" version "4.0.0"
 	id("org.ethelred.kiwiproc") version "0.7"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,5 +10,5 @@ repositories {
 dependencies {
     implementation 'com.github.jakemarsden:git-hooks-gradle-plugin:0.0.2'
 
-    implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.25.0'
+    implementation 'com.diffplug.spotless:spotless-plugin-gradle:8.4.0'
 }

--- a/buildSrc/src/main/groovy/org.ethelred.kv2.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.ethelred.kv2.java-conventions.gradle
@@ -22,7 +22,7 @@ spotless {
     format 'misc', {
         target '*.md', '.gitignore'
         trimTrailingWhitespace()
-        indentWithSpaces()
+        leadingTabsToSpaces()
         endWithNewline()
     }
     java {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/rosterParser/src/test/java/org/ethelred/roster/RosterParserTest.java
+++ b/rosterParser/src/test/java/org/ethelred/roster/RosterParserTest.java
@@ -26,8 +26,7 @@ public class RosterParserTest {
 
     @Test
     public void sample1() {
-        var body =
-                """
+        var body = """
 # Furnace Fraggers (Wastes)
 
 Gang

--- a/src/main/java/org/ethelred/kv2/data/IdentityDao.java
+++ b/src/main/java/org/ethelred/kv2/data/IdentityDao.java
@@ -7,8 +7,7 @@ import org.jspecify.annotations.Nullable;
 
 @DAO
 public interface IdentityDao {
-    @SqlUpdate(
-            """
+    @SqlUpdate("""
             INSERT INTO identity (id, provider, user_id, external_id, email, attributes)
             VALUES (:id, :provider, :userId, :externalId, :email, :attributes)
             """)

--- a/src/main/java/org/ethelred/kv2/data/SimpleRosterDao.java
+++ b/src/main/java/org/ethelred/kv2/data/SimpleRosterDao.java
@@ -24,16 +24,14 @@ public interface SimpleRosterDao {
             @Nullable LocalDateTime createdAt,
             @Nullable LocalDateTime updatedAt) {}
 
-    @SqlQuery(
-            """
+    @SqlQuery("""
             SELECT id, title
             FROM simple_roster
             WHERE owner_id = :ownerId
             """)
     List<DocumentStub> findByOwner(String ownerId);
 
-    @SqlQuery(
-            """
+    @SqlQuery("""
             SELECT sr.id, sr.title, sr.body, sr.visibility, sr.created_at, sr.updated_at,
                    u.id AS owner_id, u.display_name AS owner_display_name,
                    u.picture_url AS owner_picture_url, u.flags AS owner_flags
@@ -43,15 +41,13 @@ public interface SimpleRosterDao {
             """)
     Optional<RosterRow> findRosterRowById(String id);
 
-    @SqlUpdate(
-            """
+    @SqlUpdate("""
             INSERT INTO simple_roster (id, title, body, owner_id, visibility)
             VALUES (:id, :title, :body, :ownerId, :visibility)
             """)
     boolean insertRoster(String id, String title, String body, String ownerId, String visibility);
 
-    @SqlUpdate(
-            """
+    @SqlUpdate("""
             UPDATE simple_roster
             SET title = :title, body = :body, visibility = :visibility
             WHERE id = :id

--- a/src/main/java/org/ethelred/kv2/data/UserDao.java
+++ b/src/main/java/org/ethelred/kv2/data/UserDao.java
@@ -10,16 +10,14 @@ import org.jspecify.annotations.Nullable;
 
 @DAO
 public interface UserDao {
-    @SqlQuery(
-            """
+    @SqlQuery("""
             SELECT id, display_name, picture_url, flags, created_at, updated_at
             FROM user
             WHERE id = :id
             """)
     Optional<User> findById(String id);
 
-    @SqlQuery(
-            """
+    @SqlQuery("""
             SELECT u.id, u.display_name, u.picture_url, u.flags, u.created_at, u.updated_at
             FROM user u
             JOIN identity i ON u.id = i.user_id
@@ -28,8 +26,7 @@ public interface UserDao {
             """)
     Optional<User> findByIdentity(String provider, String externalId);
 
-    @SqlUpdate(
-            """
+    @SqlUpdate("""
             INSERT INTO user (id, display_name, picture_url, flags)
             VALUES (:id, :displayName, :pictureUrl, :flags)
             """)

--- a/src/test/java/org/ethelred/kv2/controllers/ApiRosterControllerTest.java
+++ b/src/test/java/org/ethelred/kv2/controllers/ApiRosterControllerTest.java
@@ -147,8 +147,7 @@ public class ApiRosterControllerTest {
 
     @Test
     public void createRosterWithTitle() throws Exception {
-        var body =
-                """
+        var body = """
                 # My First Roster
 
                 Big Detachment

--- a/src/test/java/org/ethelred/kv2/providers/TestDataLoader.java
+++ b/src/test/java/org/ethelred/kv2/providers/TestDataLoader.java
@@ -50,14 +50,12 @@ public class TestDataLoader {
     }
 
     private void _insert(Connection conn, DataMapping mapping) throws SQLException {
-        try (var s = conn.prepareStatement(
-                """
+        try (var s = conn.prepareStatement("""
             LOAD DATA LOCAL INFILE ?
             INTO TABLE %s
             FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
             IGNORE 1 LINES
-            """
-                        .formatted(mapping.tablename()))) {
+            """.formatted(mapping.tablename()))) {
             s.setURL(1, mapping.path());
             s.execute();
         }


### PR DESCRIPTION
## Summary

- Upgrades Gradle wrapper from 8.14.4 to 9.5.0
- Removes unused `com.github.johnrengelman.shadow` plugin (no `shadowJar` tasks exist anywhere, no Dockerfile, README notes no production deployment)
- Upgrades Spotless from 6.25.0 → 8.4.0 (Spotless 6 uses `JavaPluginConvention`, removed in Gradle 9; 7+ required)
- Replaces deprecated `indentWithSpaces()` with `leadingTabsToSpaces()` (Spotless 8 API rename)
- Spotless 8 / Palantir Java Format reformats several Java files (text-block annotation style)

The previous Renovate PR #389 was blocked by the Micronaut Gradle plugin (which bundled an incompatible Shadow version). That's now moot — Micronaut was fully removed in PRs #444 and #445. This PR supersedes and closes #389.

Closes #389

## Test plan

- [x] `./gradlew build` passes locally (all 72 tasks, including full test suite)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)