### PR TITLE
Replace jdbc:tc: URL with explicit MySQLContainer lifecycle

### DIFF
--- a/src/test/java/org/ethelred/kv2/Kv2Test.java
+++ b/src/test/java/org/ethelred/kv2/Kv2Test.java
@@ -5,7 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.avaje.inject.BeanScope;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(MySQLContainerExtension.class)
 class Kv2Test {
 
     @Test

--- a/src/test/java/org/ethelred/kv2/MySQLContainerExtension.java
+++ b/src/test/java/org/ethelred/kv2/MySQLContainerExtension.java
@@ -1,0 +1,36 @@
+/* (C) Edward Harman and contributors 2022-2026 */
+package org.ethelred.kv2;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.containers.MySQLContainer;
+
+public class MySQLContainerExtension
+        implements BeforeAllCallback, ExtensionContext.Store.CloseableResource, AutoCloseable {
+
+    private static final String STORE_KEY = "MySQLContainerExtension";
+    private MySQLContainer<?> container;
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        var store = context.getRoot().getStore(ExtensionContext.Namespace.GLOBAL);
+        if (store.get(STORE_KEY) == null) {
+            container = new MySQLContainer<>("mysql:8")
+                    .withDatabaseName("db")
+                    .withUsername("kv2")
+                    .withPassword("12345")
+                    .withConfigurationOverride("data/mysql-conf");
+            container.start();
+            System.setProperty(
+                    "datasource.url", container.getJdbcUrl() + "?allowLoadLocalInfile=true&allowUrlInLocalInfile=true");
+            store.put(STORE_KEY, this);
+        }
+    }
+
+    @Override
+    public void close() {
+        if (container != null && container.isRunning()) {
+            container.stop();
+        }
+    }
+}

--- a/src/test/java/org/ethelred/kv2/controllers/ApiRosterControllerTest.java
+++ b/src/test/java/org/ethelred/kv2/controllers/ApiRosterControllerTest.java
@@ -16,6 +16,7 @@ import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
 import javax.sql.DataSource;
+import org.ethelred.kv2.MySQLContainerExtension;
 import org.ethelred.kv2.models.DocumentStub;
 import org.ethelred.kv2.models.SimpleRoster;
 import org.ethelred.kv2.providers.TestDataLoader;
@@ -27,7 +28,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(MySQLContainerExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ApiRosterControllerTest {
     private BeanScope scope;

--- a/src/test/java/org/ethelred/kv2/data/UserRepositoryTest.java
+++ b/src/test/java/org/ethelred/kv2/data/UserRepositoryTest.java
@@ -5,10 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.avaje.inject.BeanScope;
+import org.ethelred.kv2.MySQLContainerExtension;
 import org.ethelred.kv2.models.Identity;
 import org.ethelred.kv2.models.User;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(MySQLContainerExtension.class)
 public class UserRepositoryTest {
 
     @Test

--- a/src/test/java/org/ethelred/kv2/services/UserServiceTest.java
+++ b/src/test/java/org/ethelred/kv2/services/UserServiceTest.java
@@ -5,8 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.avaje.inject.BeanScope;
 import java.util.Map;
+import org.ethelred.kv2.MySQLContainerExtension;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(MySQLContainerExtension.class)
 public class UserServiceTest {
 
     @Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,3 +1,1 @@
-datasource:
-  url: "jdbc:tc:mysql:8:///db?allowLoadLocalInfile=true&allowUrlInLocalInfile=true&TC_MY_CNF=data/mysql-conf"
-  driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
+# Test profile — datasource URL set by MySQLContainerExtension at runtime


### PR DESCRIPTION
## Summary

- Introduces `MySQLContainerExtension` — a JUnit 5 extension that starts a single shared `MySQLContainer` per JVM session using `ExtensionContext.Store.GLOBAL`, then stops it cleanly via `AutoCloseable.close()` when JUnit Platform shuts down
- Removes the `jdbc:tc:` URL pattern and `ContainerDatabaseDriver` from `application-test.yml`; the container's JDBC URL is wired into Avaje Config via a system property set before any `BeanScope` is constructed
- Adds `@ExtendWith(MySQLContainerExtension.class)` to all four database test classes

Fixes the accumulation of MySQL Docker containers across test sessions. Previously, each `BeanScope` construction triggered `ContainerDatabaseDriver` to create a container, and containers were left running if the JVM exited abnormally. Now there is exactly one container per `./gradlew test` run, and it is stopped deterministically on completion.

Also removes the dependency on `jdbc:tc:` URL support, which is dropped in Testcontainers v2.

## Test plan

- [x] `./gradlew test` passes locally
- [x] `docker ps --filter ancestor=mysql` returns no rows after the test run completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)