### PR TITLE
Fix CI: pin pnpm to 11.11.0, stop automerging pnpm bumps

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,7 +27,7 @@ jobs:
         node-version: 24
     - uses: pnpm/action-setup@v6
       with:
-        version: 11
+        version: 11.11.0
     - name: Build with Gradle
       uses: gradle/gradle-build-action@v3
       with:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 java temurin-25.0.3+9.0.LTS
 nodejs 24.18.0
-pnpm 11.12.0
+pnpm 11.11.0

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,19 @@
 {
     "extends": ["config:recommended"],
-    "packageRules": [{
-        "automerge": true,
-        "matchUpdateTypes": [
-            "minor",
-            "patch",
-            "pin",
-            "digest"
-        ]
-    }]
+    "packageRules": [
+        {
+            "automerge": true,
+            "matchUpdateTypes": [
+                "minor",
+                "patch",
+                "pin",
+                "digest"
+            ]
+        },
+        {
+            "matchDepNames": ["pnpm"],
+            "matchManagers": ["asdf"],
+            "automerge": false
+        }
+    ]
 }


### PR DESCRIPTION
## Summary
- `pnpm/action-setup@v6`'s floating `version: 11` self-upgraded to v11.12.0, whose self-installer crashes (`Cannot use 'in' operator to search for 'integrity' in undefined`), breaking every CI run since Renovate PR #548 merged — including on `main` itself.
- Pin `.github/workflows/gradle.yml` and `.tool-versions` back to the known-good pnpm 11.11.0.
- Add a Renovate `packageRules` entry so future pnpm bumps in `.tool-versions` no longer automerge, requiring a green CI run before they land.
- Also enabled a required "build" status check on `main`'s branch protection (previously none existed), so no automerged PR can land again while CI is red.

## Test plan
- [ ] Confirm the "Java CI with Gradle" run on this PR succeeds
- [ ] Confirm merging is blocked if the check is red (branch protection)