### PR TITLE
Require JWT_SECRET in production, no insecure default

### DIFF
--- a/src/main/java/org/ethelred/kv2/security/SecurityConfigFactory.java
+++ b/src/main/java/org/ethelred/kv2/security/SecurityConfigFactory.java
@@ -11,7 +11,7 @@ public class SecurityConfigFactory {
     @Bean
     public JwtConfig jwtConfig() {
         record Impl(String jwtSecret) implements JwtConfig {}
-        return new Impl(Config.get("kv2.security.jwt-secret", "MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTE="));
+        return new Impl(Config.get("kv2.security.jwt-secret"));
     }
 
     @Bean

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,3 +4,6 @@ kv2:
   jte:
     dynamic: true
     dynamic-source-path: views/src/main/jte
+  security:
+    # dev-only, insecure — never use in production
+    jwt-secret: ${JWT_SECRET:MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTE=}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,4 +31,4 @@ kv2:
       client-secret: ${DISCORD_CLIENT_SECRET:test_discord_secret}
       redirect-uri: ${DISCORD_REDIRECT_URI:http://localhost:8080/oauth/callback/discord}
   security:
-    jwt-secret: ${JWT_SECRET:MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTE=}
+    jwt-secret: ${JWT_SECRET}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,1 +1,4 @@
 # Test profile — datasource URL set by MySQLContainerExtension at runtime
+kv2:
+  security:
+    jwt-secret: MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTE=


### PR DESCRIPTION
## Summary
- The base `application.yml` previously fell back to a hardcoded, guessable JWT secret whenever `JWT_SECRET` wasn't set, so a deployment that forgot to configure it would silently issue forgeable auth tokens.
- `jwt-secret` is now required with no default in the base config, and `SecurityConfigFactory` uses the throwing `Config.get(key)` lookup, so the app now fails fast at startup in production if `JWT_SECRET` is unset.
- The previous insecure default is preserved, but scoped only to the `dev` and `test` profiles, so local dev and CI continue to work without extra setup.

## Test plan
- [x] `./gradlew :test` passes (JwtService/OAuth/ApiRosterController tests exercised, using the test-profile default secret)
- [x] `./gradlew classes` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)